### PR TITLE
Make block data (content, attributes, and props) available for SSR

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -87,7 +87,15 @@ function on_render_block( string $block_content, array $parsed_block ) : string 
 
 	if ( $block_type->ssr ) {
 		$v8js = get_v8js();
+
+		$block_ssr_data = [
+			'blockContent' => $block_content,
+			'attributes' => $parsed_block['attrs'],
+			'parsedBlock' => $parsed_block,
+		];
+
 		try {
+			$v8js->executeString( 'var blockSsrData = ' . json_encode( $block_ssr_data ) . ';' );
 			$output = execute_script( $v8js, $script_handle );
 		} catch ( Exception $e ) {
 			var_dump($e);

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -30,7 +30,7 @@ function register_scripts() {
 			'wp-element',
 			'wp-api-fetch',
 		],
-		'2022-02-09-1',
+		'2022-04-14',
 		true
 	);
 }
@@ -123,7 +123,7 @@ function on_render_block( string $block_content, array $parsed_block ) : string 
 	// Ensure the live script also receives the container.
 	add_filter(
 		'script_loader_tag',
-		function ( $tag, $script_handle ) use ( $handle, $block_type ) {
+		function ( $tag, $script_handle ) use ( $handle, $block_type, $block_ssr_data ) {
 			if ( $script_handle !== $handle ) {
 				return $tag;
 			}
@@ -132,7 +132,7 @@ function on_render_block( string $block_content, array $parsed_block ) : string 
 				return '';
 			}
 
-			$new_tag = sprintf( '<script data-container="%s" ', esc_attr( $handle ) );
+			$new_tag = sprintf( '<script data-container="%s" data-block-ssr-data="%s"', esc_attr( $handle ), esc_attr( json_encode( $block_ssr_data ) ) );
 			return str_replace( '<script ', $new_tag, $tag );
 		},
 		10,

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -107,15 +107,22 @@ function on_render_block( string $block_content, array $parsed_block ) : string 
 
 	$attributes = $parsed_block['attrs'];
 
-	if ( isset( $attributes['align'] ) && $attributes['align'] === 'full' ) {
-		$attributes['className'] .= ' alignfull';
+	// If using block props, then get the class names from the block's render method.
+	if ( preg_match( '/class="([^"]*)"/', $parsed_block['innerHTML'], $matches ) ) {
+		$class_string = $matches[1];
+	} else {
+		$class_string = $attributes['className'];
+
+		if ( isset( $attributes['align'] ) && $attributes['align'] === 'full' ) {
+			$class_string .= ' alignfull';
+		}
 	}
 
 	$output = sprintf(
 		'<div id="%s" %s class="%s">%s</div>',
 		esc_attr( $script_handle ),
 		$output ? 'data-rendered=""' : '',
-		esc_attr( $attributes['className'] ?? '' ),
+		esc_attr( $class_string ),
 		$output, // phpcs:ignore
 	);
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -30,7 +30,7 @@ function register_scripts() {
 			'wp-element',
 			'wp-api-fetch',
 		],
-		'2022-04-14',
+		'2022-04-30',
 		true
 	);
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -90,7 +90,7 @@ function on_render_block( string $block_content, array $parsed_block ) : string 
 
 		$block_ssr_data = [
 			'blockContent' => $block_content,
-			'attributes' => $parsed_block['attrs'],
+			'attributes' => $block_type->prepare_attributes_for_render( $parsed_block['attrs'] ),
 			'parsedBlock' => $parsed_block,
 		];
 

--- a/inc/ssr.js
+++ b/inc/ssr.js
@@ -23,7 +23,10 @@ const onBackend = callback => getEnvironment() === ENV_SERVER && callback();
 
 function render( getComponent, containerId ) {
 	const environment = getEnvironment();
-	const component = getComponent( environment );
+	const component = getComponent( {
+		environment,
+		...getBlockSsrData(),
+	} );
 
 	switch ( environment ) {
 		case ENV_SERVER:
@@ -81,7 +84,8 @@ function getBlockSsrData() {
 	}
 
 	// When hydrating on the frontend, parse the data attributes from the current script.
-	return JSON.parse( document.currentScript.dataset.blockSsrData );
+	const scriptDataset = document.currentScript.dataset.blockSsrData;
+	return ( typeof scriptDataset !== 'undefined' ) ? JSON.parse( scriptDataset ) : {};
 }
 
 function useApiFetch( args ) {

--- a/inc/ssr.js
+++ b/inc/ssr.js
@@ -73,6 +73,17 @@ if ( apiFetch ) {
 	} );
 }
 
+function getBlockSsrData() {
+
+	// In SSR, return the global from v8js.
+	if ( 'blockSsrData' in window ) {
+		return  window.blockSsrData;
+	}
+
+	// When hydrating on the frontend, parse the data attributes from the current script.
+	return JSON.parse( document.currentScript.dataset.blockSsrData );
+}
+
 function useApiFetch( args ) {
 	if ( getEnvironment() === 'browser' ) {
 		let defaultIsLoading = true;
@@ -122,5 +133,6 @@ window.BlockEditorSSR = {
 	onBackend: onBackend,
 	onFrontend: onFrontend,
 	getEnvironment: getEnvironment,
+	getBlockSsrData: getBlockSsrData,
 	useApiFetch: useApiFetch,
 };


### PR DESCRIPTION
It's helpful in building dynamic blocks to have access to block attributes when rendering the block, but this wasn't exposed anywhere that I could find.

This change adds a `getBlockSsrData()` function which can be accessed in the render script to retrieve attributes, block props, or other data from the block, like so:

	const { attributes, blockContent } = getBlockSsrData();

This correctly handles attribute retrieval in both SSR and client-side hydration. On the client side it relies on setting a data attribute on the script tag, which is accessed using `document.currentScript`, so this will only work for a single block instance, and assumes that each block has a separate render script. This isn't ideal, but since the implementation currently relies on a unique container ID for each script, it's not breaking any existing functionality.