### PR TITLE
Prevent console error in pages without blocks

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -30,7 +30,7 @@ function register_scripts() {
 			'wp-element',
 			'wp-api-fetch',
 		],
-		'2022-04-30',
+		'2022-05-03',
 		true
 	);
 }

--- a/inc/ssr.js
+++ b/inc/ssr.js
@@ -38,6 +38,9 @@ function render( getComponent, containerId ) {
 				return;
 			}
 			const container = document.getElementById( containerId );
+			if ( ! container ) {
+				return;
+			}
 			const didRender = 'rendered' in container.dataset;
 			if ( didRender ) {
 				ReactDOMHydrate(


### PR DESCRIPTION
I missed an issue in the last PR, where the render() callback for a block is triggered on all pages, whether or not the block exists on that page, and as a result there's an error being thrown warning that `container is null`.

Fixes errors like this:

![image](https://user-images.githubusercontent.com/665992/166562140-ad6ef2e7-4d92-45aa-a78c-086a0f423de6.png)

in situations where it's not feasible to enqueue the block scripts only when a block is rendered.